### PR TITLE
Comparing thresholds in the backend, filtering recordings list 

### DIFF
--- a/backend/db/models/speechData.js
+++ b/backend/db/models/speechData.js
@@ -12,17 +12,27 @@ const SpeechDataSchema = new mongoose.Schema({
     pitch: { type: Number, required: true },
     speed: { type: Number, required: true },
   },
+  thresholds: {
+    volume_min: { type: Number, required: true },
+    volume_max: { type: Number, required: true },
+    pitch_min: { type: Number, required: true },
+    pitch_max: { type: Number, required: true },
+    speed_min: { type: Number, required: true },
+    speed_max: { type: Number, required: true },
+  },
   audio_notes: [
     {
       type: String,
       enum: [
         "fast",
         "slow",
-        "high pitch",
-        "low pitch",
+        "normal-speed",
+        "high-pitch",
+        "low-pitch",
+        "normal-pitch",
         "loud",
         "quiet",
-        "normal",
+        "normal-volume"
       ],
     },
   ],

--- a/backend/index.js
+++ b/backend/index.js
@@ -15,6 +15,7 @@ const authRouter = require("./routes/auth");
 const speechDataRouter = require("./routes/speechData");
 const thresholdsRouter = require("./routes/thresholds");
 const accessRouter = require("./routes/access");
+const Thresholds = require("./db/models/thresholds");
 
 // Connect to MongoDB
 connectDB();
@@ -35,6 +36,50 @@ const s3 = new S3Client({
   },
 });
 
+// Helper function to determine audio notes based on metrics and thresholds
+const getAudioNotes = (metrics, thresholds) => {
+  const notes = [];
+  
+  // Volume checks
+  if (metrics.volume > thresholds.volume_max) {
+    notes.push("loud");
+  } else if (metrics.volume < thresholds.volume_min) {
+    notes.push("quiet");
+  } else {
+    notes.push("normal-volume");
+  }
+
+  // Pitch checks
+  if (metrics.pitch > thresholds.pitch_max) {
+    notes.push("high-pitch");
+  } else if (metrics.pitch < thresholds.pitch_min) {
+    notes.push("low-pitch");
+  } else {
+    notes.push("normal-pitch");
+  }
+
+  // Speed checks
+  if (metrics.speed > thresholds.speed_max) {
+    notes.push("fast");
+  } else if (metrics.speed < thresholds.speed_min) {
+    notes.push("slow");
+  } else {
+    notes.push("normal-speed");
+  }
+  
+  return notes;
+};
+
+// Helper function to check if metrics are outside thresholds
+const isOutsideThresholds = (metrics, thresholds) => {
+  return metrics.volume > thresholds.volume_max ||
+         metrics.volume < thresholds.volume_min ||
+         metrics.pitch > thresholds.pitch_max ||
+         metrics.pitch < thresholds.pitch_min ||
+         metrics.speed > thresholds.speed_max ||
+         metrics.speed < thresholds.speed_min;
+};
+
 // Endpoint to upload an audio file
 app.post("/api/upload", upload.single("audio"), async (req, res) => {
   try {
@@ -43,31 +88,17 @@ app.post("/api/upload", upload.single("audio"), async (req, res) => {
       return res.status(400).json({ error: "No file uploaded" });
     }
 
-    const audioFilePath = req.file.path; // Local path to the uploaded file
+    const audioFilePath = req.file.path;
     const audioFileName = req.file.originalname;
-    const s3Key = `recordings/${uuidv4()}${audioFileName}`;
+    const userId = "67b401b7550a00da2009bc32"; // hard coded for now
 
-    console.log(audioFilePath);
-    console.log(audioFileName);
+    // Get user's thresholds
+    const userThresholds = await Thresholds.findOne({ user_id: userId });
+    if (!userThresholds) {
+      return res.status(404).json({ error: "No thresholds found for user" });
+    }
 
-    console.log(`Received file: ${audioFileName}`);
-
-    const uploadParams = {
-      Bucket: process.env.AWS_S3_BUCKET_NAME,
-      Key: s3Key,
-      Body: fs.createReadStream(audioFilePath),
-      ContentType: req.file.mimetype,
-    };
-
-    console.log("uploadParams: ", uploadParams);
-
-    // Upload file to S3
-    await s3.send(new PutObjectCommand(uploadParams));
-
-    // Generate the S3 URL
-    const s3Url = `https://${process.env.AWS_S3_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${s3Key}`;
-
-    console.log("s3url", s3Url);
+    console.log("userThresholds: ", userThresholds);
 
     // Send the file to the Python microservice
     const microserviceUrl = "http://localhost:8001/process";
@@ -80,19 +111,50 @@ app.post("/api/upload", upload.single("audio"), async (req, res) => {
       },
     });
 
-    console.log(response);
+    console.log('response: ', response.data)
+
+    // Prepare metrics
+    const metrics = {
+      volume: 65, // hard coded for now
+      pitch: response.data.f0_mean,
+      speed: response.data.rate_of_speech,
+    };
+
+    let s3Url = null;
+
+    // Only upload to S3 if metrics are outside thresholds
+    if (isOutsideThresholds(metrics, userThresholds)) {
+      const s3Key = `recordings/${uuidv4()}${audioFileName}`;
+      const uploadParams = {
+        Bucket: process.env.AWS_S3_BUCKET_NAME,
+        Key: s3Key,
+        Body: fs.createReadStream(audioFilePath),
+        ContentType: req.file.mimetype,
+      };
+
+      await s3.send(new PutObjectCommand(uploadParams));
+      s3Url = `https://${process.env.AWS_S3_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${s3Key}`;
+    }
+
+    // Get audio notes based on metrics comparison
+    const audioNotes = getAudioNotes(metrics, userThresholds);
+
+    console.log("audioNotes: ", audioNotes);
 
     const speechDataPayload = {
-      user_id: "67b401b7550a00da2009bc32", // hard coded for now
+      user_id: userId,
       date_recorded: new Date(),
-      metrics:
-        {
-          volume: 65, // hard coded for now
-          pitch: response.data.f0_mean,
-          speed: response.data.rate_of_speech,
-        } || {}, // Ensure metrics are included
-      audio_notes: response.data.audio_notes || "normal", // Optional notes
-      recording_url: s3Url, // Store S3 URL in speechData
+      metrics,
+      thresholds: {
+        volume_min: userThresholds.volume_min,
+        volume_max: userThresholds.volume_max,
+        pitch_min: userThresholds.pitch_min,
+        pitch_max: userThresholds.pitch_max,
+        speed_min: userThresholds.speed_min,
+        speed_max: userThresholds.speed_max,
+      },
+      audio_notes: audioNotes,
+      recording_url: s3Url, // Will be null if within thresholds
     };
 
     console.log("speechDataPayload: ", speechDataPayload);
@@ -102,15 +164,14 @@ app.post("/api/upload", upload.single("audio"), async (req, res) => {
       speechDataPayload,
     );
 
-    console.log("speechDataResponse: ", speechDataResponse.data);
-
     // Delete the local file after processing
     fs.unlinkSync(audioFilePath);
 
     // Send the response back to the client
     res.status(200).json({
-      message: "File uploaded and speech data saved successfully",
+      message: "Speech data processed successfully",
       speechData: speechDataResponse.data,
+      isOutsideThresholds: s3Url !== null,
     });
   } catch (error) {
     console.error("Error processing audio:", error.message);

--- a/backend/routes/speechData.js
+++ b/backend/routes/speechData.js
@@ -54,24 +54,39 @@ router.post("/", async (req, res) => {
       user_id,
       date_recorded,
       metrics,
-      audio_url,
+      thresholds,
       audio_notes,
       recording_url,
     } = req.body;
 
     // Validate required fields
-    if (!user_id || !metrics) {
+    if (!user_id || !metrics || !thresholds) {
       return res
         .status(400)
-        .json({ error: "User ID and metrics are required." });
+        .json({ error: "User ID, metrics, and thresholds are required." });
+    }
+
+    // Validate audio_notes format
+    const validNotes = [
+      "fast", "slow", "normal-speed",
+      "high-pitch", "low-pitch", "normal-pitch",
+      "loud", "quiet", "normal-volume"
+    ];
+
+    const invalidNotes = audio_notes.filter(note => !validNotes.includes(note));
+    if (invalidNotes.length > 0) {
+      return res.status(400).json({
+        error: `Invalid audio notes: ${invalidNotes.join(", ")}`,
+        validNotes
+      });
     }
 
     // Create a new SpeechData instance
     const speechData = new SpeechData({
       user_id,
-      date_recorded: date_recorded || new Date(), // Use the current date if none is provided
+      date_recorded: date_recorded || new Date(),
       metrics,
-      audio_url,
+      thresholds,
       audio_notes,
       recording_url,
     });
@@ -98,7 +113,7 @@ router.get("/:userId/recordings", async (req, res) => {
     const { userId } = req.params;
     const recordings = await SpeechData.find(
       { user_id: userId, recording_url: { $exists: true, $ne: null } },
-      { recording_url: 1, date_recorded: 1, _id: 0 },
+      { recording_url: 1, date_recorded: 1, audio_notes: 1, _id: 0 },
     ).sort({ date_recorded: -1 });
 
     if (!recordings.length) {

--- a/frontend/src/components/Graph.js
+++ b/frontend/src/components/Graph.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -12,6 +13,7 @@ import {
 import { Line } from 'react-chartjs-2';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import { Radio } from 'antd';
 
 // Extend dayjs with the customParseFormat plugin
 dayjs.extend(customParseFormat);
@@ -19,81 +21,110 @@ dayjs.extend(customParseFormat);
 // Register Chart.js components
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
-const GraphComponent = ({ speechData, selectedDate, thresholds }) => {
+const GraphComponent = ({ speechData, selectedDate }) => {
+  const [displayMode, setDisplayMode] = useState('inRange'); // 'inRange', 'aboveRange', 'belowRange'
+
   if (!selectedDate || speechData.length === 0) {
     return <p>Please select a date to view the graph.</p>;
   }
-  console.log('speechData: ', speechData);
-  console.log('thresholds: ', thresholds);
-  console.log('selectedDate: ', selectedDate);
 
   const parsedDate = dayjs(selectedDate, 'MMMM Do, YYYY');
-
   const dates = Array.from({ length: 7 }, (_, i) => parsedDate.add(i, 'day').format('YYYY-MM-DD'));
 
-  console.log('dates: ', dates);
-
-  // Helper function to calculate percentages within range for a specific metric and date
-  const calculatePercentageForMetric = (metric, date) => {
-    console.log('date: ', date);
+  // Helper function to calculate percentages for each range type
+  const calculatePercentages = (date, rangeType) => {
     const dataForDate = speechData.filter((entry) =>
-      // console.log(entry)
       dayjs(entry.date_recorded).isSame(date, 'day')
     );
 
-    if (dataForDate.length === 0) return 0;
+    if (dataForDate.length === 0) return { volume: 0, pitch: 0, speed: 0 };
 
-    console.log('dataForDate: ', dataForDate);
+    const getMetricStatus = (notes, metric) => {
+      const normalNote = `normal-${metric}`;
+      const aboveNotes = {
+        volume: 'loud',
+        pitch: 'high-pitch',
+        speed: 'fast'
+      };
+      const belowNotes = {
+        volume: 'quiet',
+        pitch: 'low-pitch',
+        speed: 'slow'
+      };
 
-    const withinRangeCount = dataForDate.filter(
-      (entry) =>
-        entry.metrics[metric] >= thresholds[`${metric}_min`] &&
-        entry.metrics[metric] <= thresholds[`${metric}_max`]
-    ).length;
+      if (rangeType === 'inRange') return notes.includes(normalNote);
+      if (rangeType === 'aboveRange') return notes.includes(aboveNotes[metric]);
+      if (rangeType === 'belowRange') return notes.includes(belowNotes[metric]);
+      return false;
+    };
 
-    return (withinRangeCount / dataForDate.length) * 100;
+    const metrics = {
+      volume: 0,
+      pitch: 0,
+      speed: 0
+    };
+
+    Object.keys(metrics).forEach(metric => {
+      const matchingEntries = dataForDate.filter(entry => 
+        getMetricStatus(entry.audio_notes, metric)
+      ).length;
+      metrics[metric] = (matchingEntries / dataForDate.length) * 100;
+    });
+
+    return metrics;
   };
 
-  // Calculate percentages for each metric over the week
-  const metrics = ['volume', 'pitch', 'speed'];
-  const percentages = metrics.map((metric) =>
-    dates.map((date) => calculatePercentageForMetric(metric, date))
-  );
+  // Calculate percentages for all dates
+  const percentages = dates.map(date => calculatePercentages(date, displayMode));
 
   // Prepare chart data
   const chartData = {
-    labels: dates.map((date) => dayjs(date).format('MMM D, YYYY')), // Format dates for the x-axis
+    labels: dates.map(date => dayjs(date).format('D')),
     datasets: [
       {
-        label: '% Volume Within Target Range',
-        data: percentages[0], // Volume percentages
-        borderColor: 'rgba(255, 99, 132, 1)',
-        backgroundColor: 'rgba(255, 99, 132, 0.2)',
-        borderWidth: 2,
-        fill: false
+        label: 'Volume',
+        data: percentages.map(p => p.volume),
+        borderColor: '#36A2EB',
+        backgroundColor: '#36A2EB',
+        tension: 0.4
       },
       {
-        label: '% Pitch Within Target Range',
-        data: percentages[1], // Pitch percentages
-        borderColor: 'rgba(54, 162, 235, 1)',
-        backgroundColor: 'rgba(54, 162, 235, 0.2)',
-        borderWidth: 2,
-        fill: false
+        label: 'Pitch',
+        data: percentages.map(p => p.pitch),
+        borderColor: '#FF9F40',
+        backgroundColor: '#FF9F40',
+        tension: 0.4
       },
       {
-        label: '% Speed Within Target Range',
-        data: percentages[2], // Speed percentages
-        borderColor: 'rgba(75, 192, 192, 1)',
-        backgroundColor: 'rgba(75, 192, 192, 0.2)',
-        borderWidth: 2,
-        fill: false
+        label: 'Speed',
+        data: percentages.map(p => p.speed),
+        borderColor: '#4BC0C0',
+        backgroundColor: '#4BC0C0',
+        tension: 0.4
       }
     ]
   };
 
+  const titles = {
+    inRange: 'Percentage in Target Range',
+    aboveRange: 'Percentage Above Target Range',
+    belowRange: 'Percentage Below Target Range'
+  };
+
   return (
     <div>
-      <h2>Speech Metrics Analysis</h2>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
+        <h2>{titles[displayMode]}</h2>
+        <Radio.Group 
+          value={displayMode} 
+          onChange={(e) => setDisplayMode(e.target.value)}
+          buttonStyle="solid"
+        >
+          <Radio.Button value="inRange">Level</Radio.Button>
+          <Radio.Button value="aboveRange">Above Range</Radio.Button>
+          <Radio.Button value="belowRange">Below Range</Radio.Button>
+        </Radio.Group>
+      </div>
       <Line
         data={chartData}
         options={{
@@ -110,14 +141,29 @@ const GraphComponent = ({ speechData, selectedDate, thresholds }) => {
               max: 100,
               title: {
                 display: true,
-                text: 'Percentage Within Target Range (%)'
+                text: 'Percentage (%)'
               }
+            }
+          },
+          plugins: {
+            legend: {
+              position: 'top'
             }
           }
         }}
       />
     </div>
   );
+};
+
+GraphComponent.propTypes = {
+  speechData: PropTypes.arrayOf(
+    PropTypes.shape({
+      date_recorded: PropTypes.string.isRequired,
+      audio_notes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    })
+  ).isRequired,
+  selectedDate: PropTypes.string
 };
 
 export default GraphComponent;

--- a/frontend/src/pages/PatientDashboard.js
+++ b/frontend/src/pages/PatientDashboard.js
@@ -6,7 +6,7 @@ import DatePickerDropdown from '../components/DatePickerDropdown';
 import Graph from '../components/Graph';
 import dayjs from 'dayjs';
 import axios from 'axios';
-import { Card, Row, Col, Statistic } from 'antd';
+import { Card, Row, Col, Statistic, Tabs } from 'antd';
 import RecordingsList from '../components/RecordingsList';
 
 const PatientDashboard = () => {
@@ -26,17 +26,12 @@ const PatientDashboard = () => {
   useEffect(() => {
     if (speechData.length > 0) {
       const totalRecordings = speechData.length;
-      console.log('speechData: ', speechData);
       const avgVolume =
         speechData.reduce((sum, data) => sum + data.metrics.volume, 0) / totalRecordings;
       const avgPitch =
         speechData.reduce((sum, data) => sum + data.metrics.pitch, 0) / totalRecordings;
       const avgSpeed =
         speechData.reduce((sum, data) => sum + data.metrics.speed, 0) / totalRecordings;
-
-      console.log('avgVolume: ', avgVolume);
-      console.log('avgPitch: ', avgPitch);
-      console.log('avgSpeed: ', avgSpeed);
 
       setAnalytics({
         totalRecordings,
@@ -51,14 +46,11 @@ const PatientDashboard = () => {
   useEffect(() => {
     const fetchThresholds = async () => {
       try {
-        console.log('token: ', token);
-        console.log('userId: ', userId);
         const response = await axios.get(`http://localhost:8000/api/thresholds/${userId}`, {
           headers: { Authorization: `Bearer ${token}` }
         });
         if (response.data && response.data.length) {
-          const [threshold] = response.data; // Assuming one set of thresholds per user
-          console.log('Thresholds: ', threshold);
+          const [threshold] = response.data;
           setThresholds({
             volume_min: threshold.volume_min,
             volume_max: threshold.volume_max,
@@ -93,7 +85,6 @@ const PatientDashboard = () => {
         params: { startDate: formattedStartDate, endDate: formattedEndDate }
       });
 
-      console.log('SpeechData response:', response);
       setSpeechData(response.data);
       setSelectedDate(dateString);
     } catch (error) {
@@ -102,88 +93,112 @@ const PatientDashboard = () => {
     }
   };
 
+  const items = [
+    {
+      key: 'graph',
+      label: 'Graph',
+      children: (
+        <>
+          <div className="mb-6">
+            <DatePickerDropdown onDateChange={handleDateChange} />
+          </div>
+          <Card>
+            {thresholds ? (
+              <Graph speechData={speechData} selectedDate={selectedDate} />
+            ) : (
+              <p>Loading thresholds...</p>
+            )}
+          </Card>
+        </>
+      )
+    },
+    {
+      key: 'analytics',
+      label: 'Analytics',
+      children: (
+        <Row gutter={[16, 16]}>
+          <Col xs={24} sm={12} lg={6}>
+            <Card>
+              <Statistic
+                title="Total Recordings"
+                value={analytics.totalRecordings}
+                prefix={<i className="fas fa-microphone" />}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} lg={6}>
+            <Card>
+              <Statistic
+                title="Average Volume"
+                value={analytics.avgVolume}
+                suffix="dB"
+                precision={1}
+                valueStyle={{
+                  color: analytics.avgVolume === 0 
+                  ? 'gray' 
+                  : (analytics.avgVolume > (thresholds?.volume_max || 0) || analytics.avgVolume < (thresholds?.volume_min || 0)) 
+                    ? '#cf1322' 
+                    : '#3f8600'
+                }}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} lg={6}>
+            <Card>
+              <Statistic
+                title="Average Pitch"
+                value={analytics.avgPitch}
+                suffix="Hz"
+                precision={1}
+                valueStyle={{
+                  color: analytics.avgPitch === 0 
+                  ? 'gray' 
+                  : (analytics.avgPitch > (thresholds?.pitch_max || 0) || analytics.avgPitch < (thresholds?.pitch_min || 0)) 
+                    ? '#cf1322' 
+                    : '#3f8600'
+                }}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} lg={6}>
+            <Card>
+              <Statistic
+                title="Average Speed"
+                value={analytics.avgSpeed}
+                suffix="Syll/Sec"
+                precision={1}
+                valueStyle={{
+                  color: analytics.avgSpeed === 0 
+                  ? 'gray' 
+                  : (analytics.avgSpeed > (thresholds?.speed_max || 0) || analytics.avgPitch < (thresholds?.speed_min || 0)) 
+                    ? '#cf1322' 
+                    : '#3f8600'
+                }}
+              />
+            </Card>
+          </Col>
+        </Row>
+      )
+    },
+    {
+      key: 'recordings',
+      label: 'Recordings',
+      children: <RecordingsList userId={userId} />
+    }
+  ];
+
   return (
     <div className="dashboard-layout">
       <SideBar />
       <div className="right-content">
         <TopNavBar />
         <div className="content p-6">
-          <div className="mb-6">
-            <DatePickerDropdown onDateChange={handleDateChange} />
-          </div>
-          {/* Analytics Cards */}
-          <h2 className="analytics-title">Analytics</h2>
-          <Row gutter={[16, 16]} className="mb-6">
-            <Col xs={24} sm={12} lg={6}>
-              <Card>
-                <Statistic
-                  title="Total Recordings"
-                  value={analytics.totalRecordings}
-                  prefix={<i className="fas fa-microphone" />}
-                />
-              </Card>
-            </Col>
-            <Col xs={24} sm={12} lg={6}>
-              <Card>
-                <Statistic
-                  title="Average Volume"
-                  value={analytics.avgVolume}
-                  suffix="dB"
-                  precision={1}
-                  valueStyle={{
-                    color: analytics.avgVolume === 0 
-                    ? 'gray' 
-                    : (analytics.avgVolume > (thresholds?.volume_max || 0) || analytics.avgVolume < (thresholds?.volume_min || 0)) 
-                      ? '#cf1322' 
-                      : '#3f8600'
-                  }}
-                />
-              </Card>
-            </Col>
-            <Col xs={24} sm={12} lg={6}>
-              <Card>
-                <Statistic
-                  title="Average Pitch"
-                  value={analytics.avgPitch}
-                  suffix="Hz"
-                  precision={1}
-                  valueStyle={{
-                    color: analytics.avgPitch === 0 
-                    ? 'gray' 
-                    : (analytics.avgPitch > (thresholds?.pitch_max || 0) || analytics.avgPitch < (thresholds?.pitch_min || 0)) 
-                      ? '#cf1322' 
-                      : '#3f8600'
-                  }}
-                />
-              </Card>
-            </Col>
-            <Col xs={24} sm={12} lg={6}>
-              <Card>
-                <Statistic
-                  title="Average Speed"
-                  value={analytics.avgSpeed}
-                  suffix="Syll/Sec"
-                  precision={1}
-                  valueStyle={{
-                    color: analytics.avgSpeed === 0 
-                    ? 'gray' 
-                    : (analytics.avgSpeed > (thresholds?.speed_max || 0) || analytics.avgPitch < (thresholds?.speed_min || 0)) 
-                      ? '#cf1322' 
-                      : '#3f8600'                  }}
-                />
-              </Card>
-            </Col>
-          </Row>
-          <h2 className="recordings-list-title">Recordings</h2>
-          <RecordingsList userId={userId} /> {/* Show recordings here */}
-          {/* Graph Section */}
-          <Card className="mb-6">
-            {thresholds ? (
-              <Graph speechData={speechData} selectedDate={selectedDate} thresholds={thresholds} />
-            ) : (
-              <p>Loading thresholds...</p>
-            )}
-          </Card>
+          <Tabs 
+            defaultActiveKey="graph" 
+            items={items}
+            size="large"
+            type="card"
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/TherapistDashboard.js
+++ b/frontend/src/pages/TherapistDashboard.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Card, Row, Col, Statistic, Select, Empty } from 'antd';
+import { Card, Row, Col, Statistic, Select, Empty, Tabs } from 'antd';
 import TherapistSideBar from '../components/TherapistSideBar';
 import TherapistTopNavBar from '../components/TherapistTopNavBar';
 import DatePickerDropdown from '../components/DatePickerDropdown';
@@ -142,6 +142,103 @@ const TherapistDashboard = () => {
     }
   };
 
+  const getTabItems = () => {
+    const baseItems = [
+      {
+        key: 'graph',
+        label: 'Graph',
+        children: (
+          <>
+            <div className="mb-6">
+              <DatePickerDropdown onDateChange={handleDateChange} />
+            </div>
+            <Card>
+              {thresholds ? (
+                <Graph speechData={speechData} selectedDate={selectedDate} />
+              ) : (
+                <p>Loading thresholds...</p>
+              )}
+            </Card>
+          </>
+        )
+      },
+      {
+        key: 'analytics',
+        label: 'Analytics',
+        children: (
+          <Row gutter={[16, 16]}>
+            <Col xs={24} sm={12} lg={6}>
+              <Card>
+                <Statistic
+                  title="Total Recordings"
+                  value={analytics.totalRecordings}
+                  prefix={<i className="fas fa-microphone" />}
+                />
+              </Card>
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <Card>
+                <Statistic
+                  title="Average Volume"
+                  value={analytics.avgVolume}
+                  suffix="dB"
+                  precision={1}
+                  valueStyle={{
+                    color:
+                      analytics.avgVolume > (thresholds?.volume_max || 0) ? '#cf1322' : '#3f8600'
+                  }}
+                />
+              </Card>
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <Card>
+                <Statistic
+                  title="Average Pitch"
+                  value={analytics.avgPitch}
+                  suffix="Hz"
+                  precision={1}
+                  valueStyle={{
+                    color:
+                      analytics.avgPitch > (thresholds?.pitch_max || 0) ? '#cf1322' : '#3f8600'
+                  }}
+                />
+              </Card>
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <Card>
+                <Statistic
+                  title="Average Speed"
+                  value={analytics.avgSpeed}
+                  suffix="Syll/Sec"
+                  precision={1}
+                  valueStyle={{
+                    color:
+                      analytics.avgSpeed > (thresholds?.speed_max || 0) ? '#cf1322' : '#3f8600'
+                  }}
+                />
+              </Card>
+            </Col>
+          </Row>
+        )
+      }
+    ];
+
+    // Add either Recordings or Flags tab based on access
+    const thirdTab = hasRecordingsAccess
+      ? {
+          key: 'recordings',
+          label: 'Recordings',
+          children: selectedPatient && <RecordingsList userId={selectedPatient} />
+        }
+      : {
+          key: 'flags',
+          label: 'Flags',
+          children: <Card>Flagged recordings will appear here</Card>
+        };
+
+    return [...baseItems, thirdTab];
+  };
+
   return (
     <div className="dashboard-layout">
       <TherapistSideBar
@@ -165,86 +262,15 @@ const TherapistDashboard = () => {
                 </Option>
               ))}
             </Select>
-            <DatePickerDropdown onDateChange={handleDateChange} />
           </div>
 
           {selectedPatient ? (
-            <>
-              <Row gutter={[16, 16]} className="mb-6">
-                <Col xs={24} sm={12} lg={6}>
-                  <Card>
-                    <Statistic
-                      title="Total Recordings"
-                      value={analytics.totalRecordings}
-                      prefix={<i className="fas fa-microphone" />}
-                    />
-                  </Card>
-                </Col>
-                <Col xs={24} sm={12} lg={6}>
-                  <Card>
-                    <Statistic
-                      title="Average Volume"
-                      value={analytics.avgVolume}
-                      suffix="dB"
-                      precision={1}
-                      valueStyle={{
-                        color:
-                          analytics.avgVolume > (thresholds?.volume_max || 0)
-                            ? '#cf1322'
-                            : '#3f8600'
-                      }}
-                    />
-                  </Card>
-                </Col>
-                <Col xs={24} sm={12} lg={6}>
-                  <Card>
-                    <Statistic
-                      title="Average Pitch"
-                      value={analytics.avgPitch}
-                      suffix="Hz"
-                      precision={1}
-                      valueStyle={{
-                        color:
-                          analytics.avgPitch > (thresholds?.pitch_max || 0) ? '#cf1322' : '#3f8600'
-                      }}
-                    />
-                  </Card>
-                </Col>
-                <Col xs={24} sm={12} lg={6}>
-                  <Card>
-                    <Statistic
-                      title="Average Speed"
-                      value={analytics.avgSpeed}
-                      suffix="Syll/Sec"
-                      precision={1}
-                      valueStyle={{
-                        color:
-                          analytics.avgSpeed > (thresholds?.speed_max || 0) ? '#cf1322' : '#3f8600'
-                      }}
-                    />
-                  </Card>
-                </Col>
-              </Row>
-
-              {/* Conditionally render RecordingsList based on permissions */}
-              {hasRecordingsAccess && selectedPatient && (
-                <Card className="mb-6">
-                  <RecordingsList userId={selectedPatient} />
-                </Card>
-              )}
-
-              <Card className="mb-6">
-                {thresholds ? (
-                  <Graph
-                    speechData={speechData}
-                    selectedDate={selectedDate}
-                    thresholds={thresholds}
-                  />
-                ) : (
-                  <p>Loading thresholds...</p>
-                )}
-              </Card>
-            </>
+            <Tabs 
+              defaultActiveKey="graph" 
+              items={getTabItems()}
+              size="large"
+              type="card"
+            />
           ) : (
             <Empty description="Select a patient to view their data" />
           )}


### PR DESCRIPTION
What was done
- Thresholds are now saved in the backend, and attached to speechData objects. This is done so that speechData objects will always be within or outside of the historical threshold at the time of the recording, so that when users change thresholds the speechData objects will not be compared against the new thresholds. This also allows us to add audio notes to the speechData objects in the backend, and also allows us to only upload recordings to s3 if recordings are outside of thresholds 
- Users can filter recordings by audio notes, there are audio notes on the recording cards 
- Dashboard is split into 3 different tabs - graph, analytics and recordings
- Graph now has level, above range, and below range options

What needs to be done
- Front end changes for the recordings tab to align with the designs
- Change analytics section to align with the designs
- Allow users to change the graph timeframes (daily, weekly, monthly) 
- Hoverstates for graph which show percentage within target range and threshold
- Flags section for therapist when therapist does not have recording access + remove permissions view on therapist side(?) + remove analytics permission + remove no access for target range acces
- Theshold section in settings should reflect the current threshold settings for user (therapist + patient side) 
- patient 'friend request' to therapist

