### PR TITLE
Patient share requests to therapists

### DIFF
--- a/backend/db/models/user.js
+++ b/backend/db/models/user.js
@@ -11,6 +11,11 @@ const PermissionSchema = new mongoose.Schema({
     enum: ["Can edit", "Can view", "No access"],
     default: "No access",
   },
+  status: {
+    type: String,
+    enum: ["pending", "accepted", "declined"],
+    default: "pending"
+  }
 });
 
 // Updated UserSchema to include permissions and relations

--- a/frontend/src/components/PermissionsTable.js
+++ b/frontend/src/components/PermissionsTable.js
@@ -19,18 +19,21 @@ const PermissionsTable = () => {
         headers: { Authorization: `Bearer ${token}` }
       });
 
-      // Transform the data to match our table structure
-      const transformedData = response.data.sharedWith.map((item, index) => ({
-        key: item.userId._id,
-        name: item.userId.name,
-        initials: item.userId.initials,
-        color: item.userId.avatarColor,
-        analytics: item.analytics,
-        recordings: item.recordings,
-        accessLevel: item.accessLevel,
-        relation: item.userId.relation,
-        email: item.userId.email
-      }));
+      // Transform the data and filter out pending requests
+      const transformedData = response.data.sharedWith
+        .filter(item => item.status === 'accepted') // Only show accepted permissions
+        .map((item, index) => ({
+          key: item.userId._id,
+          name: item.userId.name,
+          initials: item.userId.initials,
+          color: item.userId.avatarColor,
+          analytics: item.analytics,
+          recordings: item.recordings,
+          accessLevel: item.accessLevel,
+          relation: item.userId.relation,
+          email: item.userId.email,
+          status: item.status
+        }));
 
       setPermissions(transformedData);
     } catch (error) {
@@ -179,13 +182,19 @@ const PermissionsTable = () => {
 
   return (
     <div className="permissions-container">
-      <Table
-        dataSource={permissions}
-        columns={columns}
-        pagination={false}
-        loading={loading}
-        className="permissions-table"
-      />
+      {permissions.length === 0 && !loading ? (
+        <div style={{ textAlign: 'left' }}>
+          <p>No active permissions. Waiting for therapists to accept your share requests.</p>
+        </div>
+      ) : (
+        <Table
+          dataSource={permissions}
+          columns={columns}
+          pagination={false}
+          loading={loading}
+          className="permissions-table"
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/ShareModal.js
+++ b/frontend/src/components/ShareModal.js
@@ -54,6 +54,8 @@ const ShareModal = ({ open, onClose, onSuccess }) => {
 
       if (error.response && error.response.status === 404) {
         message.error(`No user found with email ${email}`);
+      } else if (error.response && error.response.status === 400) {
+        message.error('Metrics already shared with this user');
       } else {
         message.error('Failed to share metrics. Please try again.');
       }

--- a/frontend/src/components/TherapistSideBar.js
+++ b/frontend/src/components/TherapistSideBar.js
@@ -1,12 +1,13 @@
 import React from 'react';
-import { Layout, Typography, Button, Avatar } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
+import { Layout, Typography, Button, Avatar, Badge } from 'antd';
 import vocalpalLogo from '../util/vocopalLogo.svg';
 
 const { Sider } = Layout;
 const { Title } = Typography;
 
-const TherapistSideBar = ({ patients, selectedPatient, onPatientSelect }) => {
+const TherapistSideBar = ({ patients, pendingRequests, selectedPatient, onPatientSelect, onRespondToRequest }) => {
+  const acceptedPatients = patients.filter(p => p.status === 'accepted');
+  
   return (
     <Sider
       width={240}
@@ -20,56 +21,97 @@ const TherapistSideBar = ({ patients, selectedPatient, onPatientSelect }) => {
       }}
     >
       <div style={{ padding: '16px' }}>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: '24px'
-          }}
-        >
+        <div style={{ marginBottom: '24px' }}>
           <img src={vocalpalLogo} alt="VocoPal" style={{ height: '32px' }} />
         </div>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: '16px'
-          }}
-        >
-          <Title level={5} style={{ margin: 0, color: '#666' }}>
-            PATIENTS
-          </Title>
-          <Button type="text" icon={<PlusOutlined />} style={{ border: 'none', padding: '4px' }} />
-        </div>
-      </div>
-      <div style={{ padding: '0 8px' }}>
-        {patients?.map((patient) => (
-          <div
-            key={patient.userId._id}
-            onClick={() => onPatientSelect(patient.userId._id)}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              padding: '12px 8px',
-              cursor: 'pointer',
-              borderRadius: '8px',
-              backgroundColor: selectedPatient === patient.userId._id ? '#f0f0f0' : 'transparent',
-              marginBottom: '4px'
-            }}
-          >
-            <Avatar
+        
+        {/* Requests Section */}
+        <div style={{ marginBottom: '24px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: '16px' }}>
+            <Title level={5} style={{ margin: 0, color: '#666' }}>
+              REQUESTS
+            </Title>
+            {pendingRequests.length > 0 && (
+              <Badge count={pendingRequests.length} style={{ marginLeft: '8px' }} />
+            )}
+          </div>
+          {pendingRequests.map(request => (
+            <div
+              key={request.userId._id}
               style={{
-                backgroundColor: patient.userId.avatarColor,
-                marginRight: '12px'
+                padding: '12px',
+                backgroundColor: '#fff1f0',
+                borderRadius: '8px',
+                marginBottom: '8px'
               }}
             >
-              {patient.userId.initials}
-            </Avatar>
-            <span style={{ color: '#333' }}>{patient.userId.name}</span>
-          </div>
-        ))}
+              <div style={{ display: 'flex', alignItems: 'center', marginBottom: '8px' }}>
+                <Avatar
+                  style={{
+                    backgroundColor: request.userId.avatarColor,
+                    marginRight: '8px'
+                  }}
+                >
+                  {request.userId.initials}
+                </Avatar>
+                <span>{request.userId.email}</span>
+              </div>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <Button
+                  size="small"
+                  onClick={() => onRespondToRequest(request.userId._id, 'declined')}
+                >
+                  Decline
+                </Button>
+                <Button
+                  type="primary"
+                  size="small"
+                  onClick={() => onRespondToRequest(request.userId._id, 'accepted')}
+                >
+                  Accept
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Patients Section */}
+        <div>
+          <Title level={5} style={{ margin: '0 0 16px', color: '#666' }}>
+            PATIENTS
+          </Title>
+          {acceptedPatients.length === 0 ? (
+            <div style={{ textAlign: 'center', color: '#666' }}>
+              No patients yet
+            </div>
+          ) : (
+            acceptedPatients.map(patient => (
+              <div
+                key={patient.userId._id}
+                onClick={() => onPatientSelect(patient.userId._id)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '12px 8px',
+                  cursor: 'pointer',
+                  borderRadius: '8px',
+                  backgroundColor: selectedPatient === patient.userId._id ? '#f0f0f0' : 'transparent',
+                  marginBottom: '4px'
+                }}
+              >
+                <Avatar
+                  style={{
+                    backgroundColor: patient.userId.avatarColor,
+                    marginRight: '12px'
+                  }}
+                >
+                  {patient.userId.initials}
+                </Avatar>
+                <span>{patient.userId.name}</span>
+              </div>
+            ))
+          )}
+        </div>
       </div>
     </Sider>
   );

--- a/frontend/src/pages/PatientSettings.js
+++ b/frontend/src/pages/PatientSettings.js
@@ -1,15 +1,38 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import SideBar from '../components/SideBar';
 import TopNavBar from '../components/TopNavBar';
 import './PatientDashboard.css';
 import ThresholdTable from '../components/ThresholdTable';
 import PermissionsTable from '../components/PermissionsTable';
 import './PatientSettings.css';
+import { Typography } from 'antd';
+import axios from 'axios';
+
+const { Text } = Typography;
 
 const PatientSettings = () => {
   const [permissionsKey, setPermissionsKey] = useState(0); // Used to force re-render of PermissionsTable
-
+  const [pendingRequests, setPendingRequests] = useState([]);
   const userId = localStorage.getItem('userId');
+  const token = localStorage.getItem('token');
+
+  // Fetch pending requests
+  useEffect(() => {
+    const fetchPendingRequests = async () => {
+      try {
+        const response = await axios.get('http://localhost:8000/api/access/shared-with', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        
+        const pending = response.data.sharedWith.filter(item => item.status === 'pending');
+        setPendingRequests(pending);
+      } catch (error) {
+        console.error('Error fetching pending requests:', error);
+      }
+    };
+
+    fetchPendingRequests();
+  }, [token]);
 
   const handleShareSuccess = () => {
     // Force re-render of PermissionsTable to show updated data
@@ -30,6 +53,18 @@ const PatientSettings = () => {
 
           <div className="settings-section">
             <h2 className="threshold-title">Permissions</h2>
+            {pendingRequests.length > 0 && (
+              <div style={{ marginBottom: '16px' }}>
+                <Text type="secondary">
+                  Pending requests ({pendingRequests.length}):
+                  {pendingRequests.map(request => (
+                    <span key={request.userId._id} style={{ marginLeft: '8px' }}>
+                      {request.userId.email}
+                    </span>
+                  ))}
+                </Text>
+              </div>
+            )}
             <PermissionsTable key={permissionsKey} />
           </div>
 


### PR DESCRIPTION
What was done
- When patients share with therapist, a share request appears on therapist side which gives therapist option to accept/ decline
- If accepted, therapists can see the aspects of the dashboard which user has given permissions for (graph, analytics, recording) 
- If declined, therapist cannot view dashboard and request is removed

What needs to be done in relation to this change
- Create empty states to reflect designs on patient + therapist side 
- Add therapist request for patient access (awaiting designs for this) 
- Change therapist setting page to show patients on the side bar, and remove permissions table and just surface the thresholds automatically

Other things that need to be done
- Front end changes for the recordings tab to align with the designs
- Allow users to change the graph timeframes (daily, weekly, monthly)
- Hoverstates for graph which show percentage within target range and threshold
- Flags section for therapist when therapist does not have recording access + remove permissions view on therapist side(?) + remove analytics permission + remove no access for target range acces
