### PR TITLE
Refactoring date selection

### DIFF
--- a/frontend/src/components/DatePickerDropdown.js
+++ b/frontend/src/components/DatePickerDropdown.js
@@ -1,18 +1,191 @@
-import React from 'react';
-import { DatePicker } from 'antd';
+import React, { useState } from 'react';
+import { DatePicker, Select, Space } from 'antd';
+import { CalendarOutlined, LeftOutlined, RightOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
 
-dayjs.extend(advancedFormat);
+const DatePickerDropdown = ({ onDateChange, value, granularity, onGranularityChange }) => {
+  const [open, setOpen] = useState(false);
 
-const DatePickerDropdown = ({ onDateChange }) => {
+  const handleDateChange = (date) => {
+    if (!date) return;
+    
+    // Convert the ISO date to dayjs and start of day to avoid timezone issues
+    const startDate = dayjs(date).startOf('day');
+
+    console.log('startDate: ', startDate);
+    let endDate;
+    let dateString;
+    
+    switch (granularity) {
+      case 'day':
+        endDate = startDate.clone().add(1, 'day');
+        dateString = startDate.format('MMM D, YYYY');
+        break;
+      case 'week':
+        endDate = startDate.clone().add(6, 'days');
+        dateString = `${startDate.format('MMM D')} - ${endDate.format('MMM D, YYYY')}`;
+        break;
+      case 'month':
+        endDate = startDate.clone().endOf('month');
+        dateString = startDate.format('MMMM YYYY');
+        break;
+      case 'year':
+        endDate = startDate.clone().endOf('year');
+        dateString = startDate.format('YYYY');
+        break;
+      default:
+        endDate = startDate.clone().add(6, 'days');
+        dateString = `${startDate.format('MMM D')} - ${endDate.format('MMM D, YYYY')}`;
+    }
+
+    onDateChange(startDate, dateString, endDate);
+    setOpen(false);
+  };
+
+  const handleNavigate = (direction) => {
+    if (!value) return;
+
+    const currentDate = dayjs(value);
+    let newDate;
+
+    switch (granularity) {
+      case 'day':
+        newDate = direction === 'forward' ? currentDate.add(1, 'day') : currentDate.subtract(1, 'day');
+        break;
+      case 'week':
+        newDate = direction === 'forward' ? currentDate.add(7, 'days') : currentDate.subtract(7, 'days');
+        break;
+      case 'month':
+        newDate = direction === 'forward' ? currentDate.add(1, 'month') : currentDate.subtract(1, 'month');
+        break;
+      case 'year':
+        newDate = direction === 'forward' ? currentDate.add(1, 'year') : currentDate.subtract(1, 'year');
+        break;
+      default:
+        newDate = direction === 'forward' ? currentDate.add(7, 'days') : currentDate.subtract(7, 'days');
+    }
+
+    handleDateChange(newDate);
+  };
+
+  // Get the formatted date range for display
+  const getDisplayDateRange = () => {
+    if (!value) return 'Select date';
+    
+    console.log('value: ', value);
+    
+    const startDate = dayjs(value);
+    let endDate;
+    
+    switch (granularity) {
+      case 'day':
+        return startDate.format('MMM D, YYYY');
+      case 'week':
+        endDate = dayjs(value).add(6, 'days');
+        return `${startDate.format('MMM D')} - ${endDate.format('MMM D, YYYY')}`;
+      case 'month':
+        return startDate.format('MMMM YYYY');
+      case 'year':
+        return startDate.format('YYYY');
+      default:
+        endDate = dayjs(value).add(6, 'days');
+        return `${startDate.format('MMM D')} - ${endDate.format('MMM D, YYYY')}`;
+    }
+  };
+
   return (
-    <div>
-      <DatePicker
-        onChange={onDateChange}
-        format={(value) => value.format('MMMM Do, YYYY')}
-        placeholder="Select a date"
-      />
+    <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+      <Space size="large">
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <CalendarOutlined 
+            style={{ fontSize: '16px', cursor: 'pointer' }} 
+            onClick={() => setOpen(!open)}
+          />
+          <span style={{ color: '#666', minWidth: '200px' }}>{getDisplayDateRange()}</span>
+          <div style={{ 
+            display: 'flex', 
+            gap: '4px',
+            background: '#f5f5f5',
+            padding: '4px',
+            borderRadius: '20px'
+          }}>
+            <div
+              style={{
+                width: '28px',
+                height: '28px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                borderRadius: '50%',
+                background: 'white',
+                border: '1px solid #d9d9d9',
+                transition: 'all 0.3s',
+                ':hover': {
+                  borderColor: '#1890ff',
+                  color: '#1890ff'
+                }
+              }}
+              onClick={() => value && handleNavigate('backward')}
+            >
+              <LeftOutlined 
+                style={{ 
+                  fontSize: '12px',
+                  color: value ? '#1890ff' : '#d9d9d9'
+                }} 
+              />
+            </div>
+            <div
+              style={{
+                width: '28px',
+                height: '28px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                borderRadius: '50%',
+                background: 'white',
+                border: '1px solid #d9d9d9',
+                transition: 'all 0.3s',
+                ':hover': {
+                  borderColor: '#1890ff',
+                  color: '#1890ff'
+                }
+              }}
+              onClick={() => value && handleNavigate('forward')}
+            >
+              <RightOutlined 
+                style={{ 
+                  fontSize: '12px',
+                  color: value ? '#1890ff' : '#d9d9d9'
+                }} 
+              />
+            </div>
+          </div>
+          <DatePicker
+            open={open}
+            style={{ position: 'absolute', opacity: 0, width: 0, height: 0 }}
+            onChange={handleDateChange}
+            value={value ? dayjs(value) : null}
+            onOpenChange={setOpen}
+            picker={granularity === 'year' ? 'year' : granularity === 'month' ? 'month' : 'date'}
+          />
+        </div>
+        <Select
+          value={granularity}
+          onChange={(value) => {
+            onGranularityChange(value);
+            setOpen(false);
+          }}
+          style={{ width: 120 }}
+          options={[
+            { value: 'day', label: 'Daily' },
+            { value: 'week', label: 'Weekly' },
+            { value: 'month', label: 'Monthly' },
+            { value: 'year', label: 'Yearly' }
+          ]}
+        />
+      </Space>
     </div>
   );
 };

--- a/frontend/src/components/TherapistSideBar.js
+++ b/frontend/src/components/TherapistSideBar.js
@@ -6,7 +6,7 @@ const { Sider } = Layout;
 const { Title } = Typography;
 
 const TherapistSideBar = ({ patients, pendingRequests, selectedPatient, onPatientSelect, onRespondToRequest }) => {
-  const acceptedPatients = patients.filter(p => p.status === 'accepted');
+  const acceptedPatients = patients?.filter(p => p.status === 'accepted');
   
   return (
     <Sider
@@ -31,11 +31,11 @@ const TherapistSideBar = ({ patients, pendingRequests, selectedPatient, onPatien
             <Title level={5} style={{ margin: 0, color: '#666' }}>
               REQUESTS
             </Title>
-            {pendingRequests.length > 0 && (
-              <Badge count={pendingRequests.length} style={{ marginLeft: '8px' }} />
+            {pendingRequests?.length > 0 && (
+              <Badge count={pendingRequests?.length} style={{ marginLeft: '8px' }} />
             )}
           </div>
-          {pendingRequests.map(request => (
+          {pendingRequests?.map(request => (
             <div
               key={request.userId._id}
               style={{
@@ -80,12 +80,12 @@ const TherapistSideBar = ({ patients, pendingRequests, selectedPatient, onPatien
           <Title level={5} style={{ margin: '0 0 16px', color: '#666' }}>
             PATIENTS
           </Title>
-          {acceptedPatients.length === 0 ? (
+          {acceptedPatients?.length === 0 ? (
             <div style={{ textAlign: 'center', color: '#666' }}>
               No patients yet
             </div>
           ) : (
-            acceptedPatients.map(patient => (
+            acceptedPatients?.map(patient => (
               <div
                 key={patient.userId._id}
                 onClick={() => onPatientSelect(patient.userId._id)}


### PR DESCRIPTION
What was done
- Added date granularity (daily, weekly, monthly, yearly) 
- Can now see a date range rendered on the front end 
- Select dates from the calendar icon 
- Arrows to move between the date ranges easily 

What needs to be done in relation to this change
- Front end changes to allign with designs
- Change the x-axis based on the granularity
- More testing with respect to timezones and the daily datapoints

Other things that need to be done
- Front end changes for the recordings tab to align with the designs
- Hoverstates for graph which show percentage within target range and threshold
- Flags section for therapist when therapist does not have recording access + remove permissions view on therapist side(?) + remove analytics permission + remove no access for target range acces